### PR TITLE
Fixed typo in carbon.dependencies preventing build

### DIFF
--- a/carbon.dependencies
+++ b/carbon.dependencies
@@ -2,7 +2,7 @@
   {
     "remote":      "github",
     "repository":  "xiaomi-sdm660/android_device_xiaomi_sdm660-common",
-    "target_path": "device/xiaomi/sdm660-common"
+    "target_path": "device/xiaomi/sdm660-common",
     "branch":      "havoc"
   },
   {


### PR DESCRIPTION
A missing comma in carbon.dependencies was causing lunch combo to fail :

```
Traceback (most recent call last):
  File "build/tools/roomservice.py", line 364, in <module>
    fetch_dependencies(device)
  File "build/tools/roomservice.py", line 311, in fetch_dependencies
    dependencies = parse_dependency_file(location)
  File "build/tools/roomservice.py", line 225, in parse_dependency_file
    raise Exception("ERROR: malformed dependency file")
Exception: ERROR: malformed dependency file
```